### PR TITLE
Fix typos that prevent compilation

### DIFF
--- a/src/main/java/org/cryptoapi/bench/brokencrypto/BrokenCryptoBBCase5.java
+++ b/src/main/java/org/cryptoapi/bench/brokencrypto/BrokenCryptoBBCase5.java
@@ -16,7 +16,7 @@ public class BrokenCryptoBBCase5 {
     }
 
     public static void main (String [] args) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException {
-        BrokenCryptoBBCase4 bc = new BrokenCryptoBBCase4();
+        BrokenCryptoBBCase5 bc = new BrokenCryptoBBCase5();
         bc.go();
     }
 }

--- a/src/main/java/org/cryptoapi/bench/brokencrypto/BrokenCryptoCorrected.java
+++ b/src/main/java/org/cryptoapi/bench/brokencrypto/BrokenCryptoCorrected.java
@@ -16,7 +16,7 @@ public class BrokenCryptoCorrected {
     }
 
     public static void main (String [] args) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException {
-        BrokenCryptoBBCorrected bc = new BrokenCryptoBBCorrected();
+        BrokenCryptoCorrected bc = new BrokenCryptoCorrected();
         bc.go();
     }
 }

--- a/src/main/java/org/cryptoapi/bench/brokencrypto/BrokenCryptoCorrected.java
+++ b/src/main/java/org/cryptoapi/bench/brokencrypto/BrokenCryptoCorrected.java
@@ -16,7 +16,7 @@ public class BrokenCryptoCorrected {
     }
 
     public static void main (String [] args) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException {
-        BrokenCryptoBBCase1 bc = new BrokenCryptoBBCase1();
+        BrokenCryptoBBCorrected bc = new BrokenCryptoBBCorrected();
         bc.go();
     }
 }

--- a/src/main/java/org/cryptoapi/bench/ecbcrypto/EcbInSymmCryptoCorrected.java
+++ b/src/main/java/org/cryptoapi/bench/ecbcrypto/EcbInSymmCryptoCorrected.java
@@ -16,7 +16,7 @@ public class EcbInSymmCryptoCorrected {
     }
 
     public static void main (String [] args) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException {
-        EcbInSymmCryptoBBCorrected bc = new EcbInSymmCryptoBBCorrected();
+        EcbInSymmCryptoCorrected bc = new EcbInSymmCryptoCorrected();
         bc.go();
     }
 }

--- a/src/main/java/org/cryptoapi/bench/ecbcrypto/EcbInSymmCryptoCorrected.java
+++ b/src/main/java/org/cryptoapi/bench/ecbcrypto/EcbInSymmCryptoCorrected.java
@@ -16,7 +16,7 @@ public class EcbInSymmCryptoCorrected {
     }
 
     public static void main (String [] args) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException {
-        EcbInSymmCryptoBBCase1 bc = new EcbInSymmCryptoBBCase1();
+        EcbInSymmCryptoBBCorrected bc = new EcbInSymmCryptoBBCorrected();
         bc.go();
     }
 }


### PR DESCRIPTION
There are three files in this benchmark that don't compile as-is. These changes fix them, which is necessary to make analyses actually run on the benchmark.