### PR TITLE
Fix StaticInitializationVectorABICase2 runtime errors

### DIFF
--- a/src/main/java/org/cryptoapi/bench/staticinitializationvector/StaticInitializationVectorABICase2.java
+++ b/src/main/java/org/cryptoapi/bench/staticinitializationvector/StaticInitializationVectorABICase2.java
@@ -10,11 +10,11 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 
 public class StaticInitializationVectorABICase2 {
-    public static final String DEFAULT_INITIALIZATION = "abcde";
+    public static final String DEFAULT_INITIALIZATION = "abcdabcdabcdabcd";
     private static char[] INITIALIZATION;
     private static char[] initialization;
     public void go() throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, InvalidAlgorithmParameterException {
-        IvParameterSpec ivSpec = new IvParameterSpec(new byte[]{Byte.parseByte(String.valueOf(initialization))});
+        IvParameterSpec ivSpec = new IvParameterSpec(String.valueOf(initialization).getBytes());
         KeyGenerator keyGen = KeyGenerator.getInstance("AES");
         SecretKey key = keyGen.generateKey();
         Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");


### PR DESCRIPTION
Hello! For anyone who might require the benchmark suite to be runnable (free of runtime errors), I have made a simple change to one of the benchmarks in the suite. - I will totally understand however if that is not the aim of this project, as I know this is mainly a benchmark for crypto API misuse detection static analysis tools.

If there is anything that is unclear or that I need to adjust , let me know :)

Two errors:
1) java.lang.NumberFormatException in line 17
2) java.security.InvalidAlgorithmParameterException in line 22


### Stack trace of Error 1: 
```
Exception in thread "main" java.lang.NumberFormatException: For input string: "abcde"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Integer.parseInt(Integer.java:580)
	at java.lang.Byte.parseByte(Byte.java:149)
	at java.lang.Byte.parseByte(Byte.java:175)
	at org.cryptoapi.bench.staticinitializationvector.StaticInitializationVectorABICase2.go(StaticInitializationVectorABICase2.java:17)
	at org.cryptoapi.bench.staticinitializationvector.StaticInitializationVectorABICase2.main(StaticInitializationVectorABICase2.java:41)
```

#### Reason for error:
  * [parseByte}(https://docs.oracle.com/javase/8/docs/api/java/lang/Byte.html#parseByte-java.lang.String-) expects the String used to denote byte values. It appears that [String.getBytes](https://docs.oracle.com/javase/7/docs/api/java/lang/String.html#getBytes()) was the intended call here.

### Stack trace of Error 2: 
```
Exception in thread "main" java.security.InvalidAlgorithmParameterException: Wrong IV length: must be 16 bytes long
	at com.sun.crypto.provider.CipherCore.init(CipherCore.java:585)
	at com.sun.crypto.provider.AESCipher.engineInit(AESCipher.java:346)
	at javax.crypto.Cipher.implInit(Cipher.java:809)
	at javax.crypto.Cipher.chooseProvider(Cipher.java:867)
	at javax.crypto.Cipher.init(Cipher.java:1399)
	at javax.crypto.Cipher.init(Cipher.java:1330)
	at org.cryptoapi.bench.staticinitializationvector.StaticInitializationVectorABICase2.go(StaticInitializationVectorABICase2.java:22)
	at org.cryptoapi.bench.staticinitializationvector.StaticInitializationVectorABICase2.main(StaticInitializationVectorABICase2.java:36)
``` 
#### Reason for error:
  * the AES IV must be 16 bytes, was previously 5



# Additional: 
  * there are actually a few instances of the 2nd runtime error in the suite currently, if you are interested to apply this fix, I will go and annotate the rest as well :) Thanks!
