### PR TITLE
Update BrokenCryptoCorrected.java

### DIFF
--- a/src/main/java/org/cryptoapi/bench/brokencrypto/BrokenCryptoCorrected.java
+++ b/src/main/java/org/cryptoapi/bench/brokencrypto/BrokenCryptoCorrected.java
@@ -16,7 +16,7 @@ public class BrokenCryptoCorrected {
     }
 
     public static void main (String [] args) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException {
-        BrokenCryptoBBCase1 bc = new BrokenCryptoBBCase1();
+        BrokenCryptoCorrected bc = new BrokenCryptoCorrected();
         bc.go();
     }
 }


### PR DESCRIPTION
In this file, you have used a wrong classname 'BrokenCryptoBBCase1', I think, in this file you should use classname 'BrokenCryptoCorrected', which makes the encryption algorithm correct.(My English is very poor.)